### PR TITLE
Added option to specify log format on handler init

### DIFF
--- a/slack_log_handler/__init__.py
+++ b/slack_log_handler/__init__.py
@@ -12,15 +12,13 @@ class SlackLogHandler(logging.Handler):
         logging.CRITICAL: ':boom:'
     }
 
-    LOG_FORMAT = '[%(levelname)s] [%(asctime)s] [%(name)s] - %(message)s'
-
-    def __init__(self, webhook_url, channel=None, username=None, emojis=None):
+    def __init__(self, webhook_url, channel=None, username=None, emojis=None, format='[%(levelname)s] [%(asctime)s] [%(name)s] - %(message)s'):
         logging.Handler.__init__(self)
         self.webhook_url = webhook_url
         self.channel = channel
         self.username = username
         self.emojis = emojis if emojis is not None else SlackLogHandler.EMOJIS
-        self.formatter = logging.Formatter(SlackLogHandler.LOG_FORMAT)
+        self.formatter = logging.Formatter(format)
 
     def _make_content(self, record):
         content = {


### PR DESCRIPTION
I need to customize the log messages sent to Slack, so I added an option to use custom formats.
